### PR TITLE
Armor Effects and Recipe rebalance

### DIFF
--- a/Content/Items/Armor/FireStoneBreastplate.cs
+++ b/Content/Items/Armor/FireStoneBreastplate.cs
@@ -14,7 +14,7 @@ namespace Pokemod.Content.Items.Armor
 	public class FireStoneBreastplate : ModItem
 	{
 		public static readonly int MaxManaIncrease = 40;
-		public static readonly int AdditiveGenericDamageBonus = 20;
+		public static readonly int AdditiveGenericDamageBonus = 10;
 		public static readonly int MaxMinionIncrease = 1;
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MaxManaIncrease, MaxMinionIncrease);
@@ -40,7 +40,7 @@ namespace Pokemod.Content.Items.Armor
 		{
 			CreateRecipe()
 				.AddIngredient(ItemID.MeteoriteBar, 15)
-				.AddIngredient<FireStoneItem>(15)
+				.AddIngredient<FireStoneItem>(2)
 				.AddTile(TileID.Anvils)
 				.Register();
 		}

--- a/Content/Items/Armor/FireStoneHelmet.cs
+++ b/Content/Items/Armor/FireStoneHelmet.cs
@@ -13,7 +13,7 @@ namespace Pokemod.Content.Items.Armor
 	[AutoloadEquip(EquipType.Head)]
 	public class FireStoneHelmet : ModItem
 	{
-		public static readonly int AdditiveGenericDamageBonus = 190;
+		public static readonly int AdditiveGenericDamageBonus = 20;
         public static readonly int MaxManaIncrease = 20;
 
         public static LocalizedText SetBonusText { get; private set; }
@@ -44,7 +44,7 @@ namespace Pokemod.Content.Items.Armor
 		// UpdateArmorSet allows you to give set bonuses to the armor.
 		public override void UpdateArmorSet(Player player) {
 			player.setBonus = SetBonusText.Value;
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f;
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f;
             player.statManaMax2 += MaxManaIncrease;
         }
 
@@ -52,7 +52,7 @@ namespace Pokemod.Content.Items.Armor
         {
             CreateRecipe()
                 .AddIngredient(ItemID.MeteoriteBar, 15)
-                .AddIngredient<FireStoneItem>(5)
+                .AddIngredient<FireStoneItem>(1)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/FireStoneLeggings.cs
+++ b/Content/Items/Armor/FireStoneLeggings.cs
@@ -13,7 +13,7 @@ namespace Pokemod.Content.Items.Armor
 	public class FireStoneLeggings : ModItem
 	{
 		public static readonly int MoveSpeedBonus = 5;
-		public static readonly int AdditiveGenericDamageBonus = 200;
+		public static readonly int AdditiveGenericDamageBonus = 10;
         public static readonly int MaxManaIncrease = 35;
 
         public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MoveSpeedBonus);
@@ -27,7 +27,7 @@ namespace Pokemod.Content.Items.Armor
 		}
 
 		public override void UpdateEquip(Player player) {
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f; 
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f; 
             player.statManaMax2 += MaxManaIncrease;
         }
 
@@ -35,7 +35,7 @@ namespace Pokemod.Content.Items.Armor
         {
             CreateRecipe()
                 .AddIngredient(ItemID.MeteoriteBar, 10)
-                .AddIngredient<FireStoneItem>(15)
+                .AddIngredient<FireStoneItem>(1)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/ThunderStoneBreastplate.cs
+++ b/Content/Items/Armor/ThunderStoneBreastplate.cs
@@ -13,7 +13,7 @@ namespace Pokemod.Content.Items.Armor
 	public class ThunderStoneBreastplate : ModItem
 	{
 		public static readonly int MaxManaIncrease = 20;
-		public static readonly int AdditiveGenericDamageBonus = 150;
+		public static readonly int AdditiveGenericDamageBonus = 10;
 		public static readonly int MaxMinionIncrease = 1;
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MaxManaIncrease, MaxMinionIncrease);
@@ -28,14 +28,14 @@ namespace Pokemod.Content.Items.Armor
 
 		public override void UpdateEquip(Player player) {
 			
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f;
-            player.GetDamage(DamageClass.Ranged) += AdditiveGenericDamageBonus / 40f;
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f;
+            player.GetDamage(DamageClass.Ranged) += AdditiveGenericDamageBonus / 200f;
         }
 
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient<ThunderStoneItem>(30)
+                .AddIngredient<ThunderStoneItem>(3)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/ThunderStoneHelmet.cs
+++ b/Content/Items/Armor/ThunderStoneHelmet.cs
@@ -14,7 +14,7 @@ namespace Pokemod.Content.Items.Armor
 	[AutoloadEquip(EquipType.Head)]
 	public class ThunderStoneHelmet : ModItem
 	{
-		public static readonly int AdditiveGenericDamageBonus = 120;
+		public static readonly int AdditiveGenericDamageBonus = 20;
 
 		public static LocalizedText SetBonusText { get; private set; }
 
@@ -44,15 +44,15 @@ namespace Pokemod.Content.Items.Armor
 		// UpdateArmorSet allows you to give set bonuses to the armor.
 		public override void UpdateArmorSet(Player player) {
 			
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f;
-            player.GetDamage(DamageClass.Ranged) += AdditiveGenericDamageBonus / 40f;
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f;
+            player.GetDamage(DamageClass.Ranged) += AdditiveGenericDamageBonus / 200f;
             player.GetModPlayer<PokemonPlayer>().maxPokemon += 1;
         }
 
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient<ThunderStoneItem>(20)
+                .AddIngredient<ThunderStoneItem>(2)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/ThunderStoneLeggings.cs
+++ b/Content/Items/Armor/ThunderStoneLeggings.cs
@@ -13,7 +13,7 @@ namespace Pokemod.Content.Items.Armor
 	public class ThunderStoneLeggings : ModItem
 	{
 		public static readonly int MoveSpeedBonus = 5;
-		public static readonly int AdditiveGenericDamageBonus = 110;
+		public static readonly int AdditiveGenericDamageBonus = 10;
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MoveSpeedBonus);
 
@@ -26,14 +26,14 @@ namespace Pokemod.Content.Items.Armor
 		}
 
 		public override void UpdateEquip(Player player) {
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f;
-            player.GetDamage(DamageClass.Ranged) += AdditiveGenericDamageBonus / 32f;
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f;
+            player.GetDamage(DamageClass.Ranged) += AdditiveGenericDamageBonus / 200f;
         }
 
         public override void AddRecipes()
         {
             CreateRecipe()
-                .AddIngredient<ThunderStoneItem>(25)
+                .AddIngredient<ThunderStoneItem>(2)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/WaterStoneBreastplate.cs
+++ b/Content/Items/Armor/WaterStoneBreastplate.cs
@@ -13,7 +13,7 @@ namespace Pokemod.Content.Items.Armor
 	public class WaterStoneBreastplate : ModItem
 	{
 		public static readonly int MaxManaIncrease = 20;
-		public static readonly int AdditiveGenericDamageBonus = 100;
+		public static readonly int AdditiveGenericDamageBonus = 10;
 		public static readonly int MaxMinionIncrease = 1;
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MaxManaIncrease, MaxMinionIncrease);
@@ -28,7 +28,7 @@ namespace Pokemod.Content.Items.Armor
 
 		public override void UpdateEquip(Player player) {
 			player.buffImmune[BuffID.OnFire] = true; // Make the player immune to Fire
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f; // Increase dealt damage for all weapon classes by 20%
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f; // Increase dealt damage for all weapon classes by 20%
             player.maxMinions += MaxMinionIncrease;
         }
         
@@ -36,7 +36,7 @@ namespace Pokemod.Content.Items.Armor
         {
             CreateRecipe()
                 .AddIngredient(ItemID.PlatinumBar, 15)
-                .AddIngredient<WaterStoneItem>(15)
+                .AddIngredient<WaterStoneItem>(2)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/WaterStoneHelmet.cs
+++ b/Content/Items/Armor/WaterStoneHelmet.cs
@@ -13,7 +13,7 @@ namespace Pokemod.Content.Items.Armor
 	[AutoloadEquip(EquipType.Head)]
 	public class WaterStoneHelmet : ModItem
 	{
-		public static readonly int AdditiveGenericDamageBonus = 80;
+		public static readonly int AdditiveGenericDamageBonus = 20;
         public static readonly int MaxMinionIncrease = 1;
 
         public static LocalizedText SetBonusText { get; private set; }
@@ -44,14 +44,14 @@ namespace Pokemod.Content.Items.Armor
 		// UpdateArmorSet allows you to give set bonuses to the armor.
 		public override void UpdateArmorSet(Player player) {
 			player.setBonus = SetBonusText.Value; 
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f;
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f;
             player.maxMinions += MaxMinionIncrease;
         }
         public override void AddRecipes()
         {
             CreateRecipe()
                 .AddIngredient(ItemID.PlatinumBar, 10)
-                .AddIngredient<WaterStoneItem>(10)
+                .AddIngredient<WaterStoneItem>(1)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/Armor/WaterStoneLeggings.cs
+++ b/Content/Items/Armor/WaterStoneLeggings.cs
@@ -14,7 +14,7 @@ namespace Pokemod.Content.Items.Armor
 	public class WaterStoneLeggings : ModItem
 	{
 		public static readonly int MoveSpeedBonus = 5;
-		public static readonly int AdditiveGenericDamageBonus = 90;
+		public static readonly int AdditiveGenericDamageBonus = 10;
         public static readonly int MaxMinionIncrease = 1;
 
         public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MoveSpeedBonus);
@@ -28,7 +28,7 @@ namespace Pokemod.Content.Items.Armor
 		}
 
 		public override void UpdateEquip(Player player) {
-			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 20f; // Increase dealt damage for all weapon classes by 20%
+			player.GetDamage<PokemonDamageClass>() += AdditiveGenericDamageBonus / 100f; // Increase dealt damage for all weapon classes by 20%
             player.maxMinions += MaxMinionIncrease;
             player.GetModPlayer<PokemonPlayer>().maxPokemon += 1;
         }
@@ -37,7 +37,7 @@ namespace Pokemod.Content.Items.Armor
         {
             CreateRecipe()
                 .AddIngredient(ItemID.PlatinumBar, 15)
-                .AddIngredient<WaterStoneItem>(10)
+                .AddIngredient<WaterStoneItem>(1)
                 .AddTile(TileID.Anvils)
                 .Register();
         }

--- a/Content/Items/EvoStones/FireStoneItem.cs
+++ b/Content/Items/EvoStones/FireStoneItem.cs
@@ -35,7 +35,7 @@ namespace Pokemod.Content.Items.EvoStones
 			CreateRecipe(1)
 				.AddIngredient(ItemID.Hellstone, 40)
 				.AddIngredient(ItemID.Obsidian, 20)
-				.AddIngredient(ItemID.AshBlock, 20)
+				.AddIngredient(ItemID.Ruby, 5)
 				.AddTile(TileID.Anvils)
 				.Register();
 	}

--- a/Content/Items/EvoStones/LeafStoneItem.cs
+++ b/Content/Items/EvoStones/LeafStoneItem.cs
@@ -33,9 +33,9 @@ namespace Pokemod.Content.Items.EvoStones
 		}
 		public override void AddRecipes() {
 			CreateRecipe(1)
-				.AddIngredient(ItemID.JungleSpores, 40)
+				.AddIngredient(ItemID.JungleSpores, 15)
 				.AddIngredient(ItemID.LivingLeafWall, 20)
-				.AddIngredient(ItemID.Emerald, 10)
+				.AddIngredient(ItemID.Emerald, 5)
 				.AddTile(TileID.Anvils)
 				.Register();
 	}

--- a/Content/Items/EvoStones/MoonStoneItem.cs
+++ b/Content/Items/EvoStones/MoonStoneItem.cs
@@ -34,7 +34,8 @@ namespace Pokemod.Content.Items.EvoStones
 		public override void AddRecipes() {
 			CreateRecipe(1)
 				.AddIngredient(ItemID.MoonCharm, 1)
-				.AddIngredient(ItemID.FallenStar, 20)
+				.AddIngredient(ItemID.FallenStar, 10)
+				.AddIngredient(ItemID.Amethyst, 5)
 				.AddTile(TileID.Anvils)
 				.Register();
 	}

--- a/Content/Items/EvoStones/ThunderStoneItem.cs
+++ b/Content/Items/EvoStones/ThunderStoneItem.cs
@@ -33,8 +33,8 @@ namespace Pokemod.Content.Items.EvoStones
 		}
 		public override void AddRecipes() {
 			CreateRecipe(1)
-				.AddIngredient(ItemID.GoldOre, 40)
-				.AddIngredient(ItemID.LightningWhelkShell, 20)
+				.AddIngredient(ItemID.GoldOre, 80)
+				.AddIngredient(ItemID.Topaz, 5)
 				.AddTile(TileID.Anvils)
 				.Register();
 	}

--- a/Content/Items/EvoStones/WaterStoneItem.cs
+++ b/Content/Items/EvoStones/WaterStoneItem.cs
@@ -33,9 +33,9 @@ namespace Pokemod.Content.Items.EvoStones
 		}
 		public override void AddRecipes() {
 			CreateRecipe(1)
-				.AddIngredient(ItemID.Waterleaf, 40)
-				.AddIngredient(ItemID.Coral, 20)
-				.AddIngredient(ItemID.SharkFin, 20)
+				.AddIngredient(ItemID.PlatinumOre, 60)
+				.AddIngredient(ItemID.Coral, 15)
+				.AddIngredient(ItemID.Sapphire, 5)
 				.AddTile(TileID.Anvils)
 				.Register();
 	}


### PR DESCRIPTION
I noticed some of the armour effects were severely overpowered, multiplying pokemon damage by up to x20 (I had a lvl 35 Golem dealing 8000 dmg with earthquake), and the crafting recipes for both the evo stones and the armors were not internally consistent and were overly expensive for the stage in progression they were obtainable (Armors were 10x more expensive than vanilla armors of the same materials, just due to the cost of the stones). This commit is mostly just my take on how it could all be better balanced, with the assumption that stronger armour sets will be introduced for later stages in the game. I'm sending it through as a pull request so it can be reviewed first.